### PR TITLE
Fix: actualize requirements to reference field in Git connection and model training

### DIFF
--- a/source/ref_connections.rst
+++ b/source/ref_connections.rst
@@ -236,7 +236,8 @@ The following fields of connection API are required:
     * ``spec.type`` - It must be equal **git**.
     * ``spec.keySecret`` - a base64 encoded SSH private key.
     * ``spec.uri`` -  GIT SSH URL, for example git@github.com:odahu/odahu-examples.git
-    * ``spec.reference`` -  a branch, tag, or commit.
+
+``spec.reference`` must be provided either in a connection OR in a model training object (:ref:`ref_trainings:General training structure`).
 
 Example of command to encode ssh key:
 

--- a/source/ref_trainings.rst
+++ b/source/ref_trainings.rst
@@ -77,6 +77,9 @@ General training structure
       # image: python:3.8
       # A connection which describes credentials to a GIT repository
       vcsName: <git-connection>
+      # Git reference (branch or tag)
+      # This must be specified here OR in Git connection itself
+      reference: master
     status:
       # One of the following states: scheduling, running, succeeded, failed, unknown
       state: running


### PR DESCRIPTION
`reference` field is marked as required for GIT connection object in docs. Actually it must be provided either in GIT connection or in model training that uses the connection.