### PR TITLE
[#368] Removed dockerfileAddCondaInstallation and dockerfileCondaEnvsLocation packager arguments

### DIFF
--- a/source/ref_packagers.rst
+++ b/source/ref_packagers.rst
@@ -243,8 +243,6 @@ The packager provides the following list of arguments:
    "threads", "integer", "4", "False", "Count of serving threads"
    "host", "string", "0.0.0.0", "False", "Host to bind"
    "dockerfileBaseImage", "string", "python:3.6", "False", "Base image for Dockerfile"
-   "dockerfileAddCondaInstallation", "boolean", "True", "False", "Add conda installation code to Dockerfile"
-   "dockerfileCondaEnvsLocation", "boolean", "/opt/conda/envs/", "False", "Conda env location in Dockerfile"
 
 The packager provides the following list of result fields:
 
@@ -378,8 +376,6 @@ The packager provides the following list of arguments:
 
    "imageName", "string", "{{ Name }}-{{ Version }}:{{ RandomUUID }}", "False", "This option provides a way to specify the Docker image name. You can hardcode the full name or specify a template. Available template values: Name (Model Name), Version (Model Version), RandomUUID. Examples: myservice:123, {{ Name }}:{{ Version }}"
    "dockerfileBaseImage", "string", "python:3.6", "False", "Base image for Dockerfile"
-   "dockerfileAddCondaInstallation", "boolean", "True", "False", "Add conda installation code to Dockerfile"
-   "dockerfileCondaEnvsLocation", "string", "/opt/conda/envs/", "False", "Conda env location in Dockerfile"
 
 The packager provides the following list of result fields:
 


### PR DESCRIPTION
From original issue https://github.com/odahu/odahu-flow/issues/368:
> While investigating we found out that dockerfileAddCondaInstallation field (as well as dockerfileCondaEnvsLocation) are not used in packagers anymore (both docker-cli and docker-rest packagers). These arguments were removed in this commit: odahu/odahu-packager@739bc1c, but docs were not updated. So now we just need to actualize docs.
