### PR TITLE
Docs for new field of Model Deployment "predictor"

### DIFF
--- a/source/ref_deployments.rst
+++ b/source/ref_deployments.rst
@@ -11,35 +11,38 @@ Additionally, it provides the following set of features:
     * Monitoring of Model Deployment
 
 ***************************
-Predictors
+Inference Servers
 ***************************
 
-A model can be deployed in ODAHU if only it is packed with a supported Inference Server (predictor).
+A model can be deployed in ODAHU if only it is packed with a supported Inference Server.
 Inference Server is typically a web service that "wraps" an ML model and lets remote clients to invoke
 the model via HTTP (or any other protocol).
 
-ODAHU currently supports 2 predictors:
+An Inference Servers that wraps the model has to be indicated in :code:`predictor` field of a Model Deployment.
 
-- ODAHU ML Server: :code:`odahu-ml-server`
-- NVIDIA Triton Server: :code:`triton`
+ODAHU currently supports several Inference Servers:
 
-ODAHU ML Server
+- ODAHU Inference Server: :code:`predictor: odahu`
+- NVIDIA Triton Inference Server: :code:`predictor: triton`
+
+ODAHU Inference Server
 ################
 
-ODAHU ML Server is an inference server that build a simple HTTP layer on top of any
+ODAHU Inference Server is an inference server that builds a simple HTTP layer on top of any
 `MLFlow model <https://www.mlflow.org/docs/latest/models.html>`_ with an HTTP layer.
 
-To pack a model into ODAHU ML Server :ref:`Docker REST <ref_packagers:Docker REST>` packager can be used.
+To pack a model into ODAHU Inference Server :ref:`Docker REST <ref_packagers:Docker REST>` packager has to be used.
 
-NVIDIA Triton Server
+NVIDIA Triton Inference Server
 ####################
 
-`Triton Server <https://github.com/triton-inference-server/server>`_ is a feature-rich inference server. To pack a model into a Triton Server,
-:ref:`Triton Packager <ref_packagers:Nvidia Triton Packager>` should be used.
+`Triton Server <https://github.com/triton-inference-server/server>`_ is a feature-rich inference server.
+To pack a model into a Triton Server, :ref:`Triton Packager <ref_packagers:Nvidia Triton Packager>` has to be used.
+
 Triton Server uses `KFServing Inference Protocol <https://github.com/kubeflow/kfserving/blob/master/docs/predict-api/v2/required_api.md>`_.
 
 ********************************************
-General deployment structure
+General Deployment Manifest Structure
 ********************************************
 
 .. code-block:: yaml

--- a/source/ref_deployments.rst
+++ b/source/ref_deployments.rst
@@ -22,11 +22,13 @@ An Inference Servers that wraps the model has to be indicated in :code:`predicto
 
 ODAHU currently supports several Inference Servers:
 
-- ODAHU Inference Server: :code:`predictor: odahu`
+- ODAHU Inference Server: :code:`predictor: odahu-ml-server`
 - NVIDIA Triton Inference Server: :code:`predictor: triton`
 
 ODAHU Inference Server
 ################
+
+Value for "predictor" field of Model Deployment: :code:`predictor: odahu-ml-server`
 
 ODAHU Inference Server is an inference server that builds a simple HTTP layer on top of any
 `MLFlow model <https://www.mlflow.org/docs/latest/models.html>`_ with an HTTP layer.
@@ -35,6 +37,8 @@ To pack a model into ODAHU Inference Server :ref:`Docker REST <ref_packagers:Doc
 
 NVIDIA Triton Inference Server
 ####################
+
+Value for "predictor" field of Model Deployment: :code:`predictor: triton`
 
 `Triton Server <https://github.com/triton-inference-server/server>`_ is a feature-rich inference server.
 To pack a model into a Triton Server, :ref:`Triton Packager <ref_packagers:Nvidia Triton Packager>` has to be used.
@@ -58,8 +62,8 @@ General Deployment Manifest Structure
     id: wine-12345
     spec:
         # Predictor is an inference backend name; required field
-        # Possible values are: odahu, triton
-        predictor: odahu
+        # Possible values are: odahu-ml-server, triton
+        predictor: odahu-ml-server
 
         # Model image is required value. Change it
         image: gcr.io/project/test-e2e-wine-1.0:b591c752-43d4-43e0-8392-9a5715b67573

--- a/source/ref_deployments.rst
+++ b/source/ref_deployments.rst
@@ -9,10 +9,34 @@ Additionally, it provides the following set of features:
     * Scale to zero
     * Dynamic Model swagger
     * Monitoring of Model Deployment
-    
-.. important::
 
-   Model could be deployed only if docker image was packaged through Docker REST packager.
+***************************
+Predictors
+***************************
+
+A model can be deployed in ODAHU if only it is packed with a supported Inference Server (predictor).
+Inference Server is typically a web service that "wraps" an ML model and lets remote clients to invoke
+the model via HTTP (or any other protocol).
+
+ODAHU currently supports 2 predictors:
+
+- ODAHU ML Server: :code:`odahu-ml-server`
+- NVIDIA Triton Server: :code:`triton`
+
+ODAHU ML Server
+################
+
+ODAHU ML Server is an inference server that build a simple HTTP layer on top of any
+`MLFlow model <https://www.mlflow.org/docs/latest/models.html>`_ with an HTTP layer.
+
+To pack a model into ODAHU ML Server :ref:`Docker REST <ref_packagers:Docker REST>` packager can be used.
+
+NVIDIA Triton Server
+####################
+
+`Triton Server <https://github.com/triton-inference-server/server>`_ is a feature-rich inference server. To pack a model into a Triton Server,
+:ref:`Triton Packager <ref_packagers:Nvidia Triton Packager>` should be used.
+Triton Server uses `KFServing Inference Protocol <https://github.com/kubeflow/kfserving/blob/master/docs/predict-api/v2/required_api.md>`_.
 
 ********************************************
 General deployment structure
@@ -30,6 +54,10 @@ General deployment structure
     #  * end with an alphanumeric character
     id: wine-12345
     spec:
+        # Predictor is an inference backend name; required field
+        # Possible values are: odahu-ml-server, triton
+        predictor: odahu-ml-server
+
         # Model image is required value. Change it
         image: gcr.io/project/test-e2e-wine-1.0:b591c752-43d4-43e0-8392-9a5715b67573
         # If the Docker image is pulled from a private Docker repository then

--- a/source/ref_deployments.rst
+++ b/source/ref_deployments.rst
@@ -58,8 +58,8 @@ General Deployment Manifest Structure
     id: wine-12345
     spec:
         # Predictor is an inference backend name; required field
-        # Possible values are: odahu-ml-server, triton
-        predictor: odahu-ml-server
+        # Possible values are: odahu, triton
+        predictor: odahu
 
         # Model image is required value. Change it
         image: gcr.io/project/test-e2e-wine-1.0:b591c752-43d4-43e0-8392-9a5715b67573

--- a/source/tutorials_wine.rst
+++ b/source/tutorials_wine.rst
@@ -616,7 +616,7 @@ Paste code into the file:
    kind: ModelDeployment
    spec:
      image: "<fill-in>"
-     predictor: odahu
+     predictor: odahu-ml-server
      minReplicas: 1
      imagePullConnectionID: docker-tutorial
 

--- a/source/tutorials_wine.rst
+++ b/source/tutorials_wine.rst
@@ -616,13 +616,15 @@ Paste code into the file:
    kind: ModelDeployment
    spec:
      image: "<fill-in>"
+     predictor: odahu-ml-server
      minReplicas: 1
      imagePullConnectionID: docker-tutorial
 
 In this file, we:
 
 - line 4: Set the ``image`` that was created in the Package step
-- line 6: Set the id of the :term:`REST API Packager`
+- line 5: Set the ``predictor`` that indicates what Inference Server is used in the image; Check `Predictors`_ for more;
+- line 7: Set the connection ID to access the container registry where the image lives
 
 Create a :term:`Deploy` using the :term:`Odahu-flow CLI`:
 

--- a/source/tutorials_wine.rst
+++ b/source/tutorials_wine.rst
@@ -616,7 +616,7 @@ Paste code into the file:
    kind: ModelDeployment
    spec:
      image: "<fill-in>"
-     predictor: odahu-ml-server
+     predictor: odahu
      minReplicas: 1
      imagePullConnectionID: docker-tutorial
 


### PR DESCRIPTION
Documented `predictor` field that allows different Inference Backends with different APIs and protocols.