### PR TITLE
#124-set mistune version to 0.8.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ sphinxcontrib-plantuml==0.18
 recommonmark==0.5.0
 doc8==0.8.0
 sphinxcontrib-openapi==0.7.0
+mistune==0.8.4
 git+https://github.com/mchehab/rst2pdf.git


### PR DESCRIPTION
Few month ago default version of mistune was set to 2.0.0, its API changed since that's why we encountered such error. Fixed by  setting version to 0.8.4 in requirements.txt